### PR TITLE
HDPI-3496: Extract initial wiremock mappings to values file

### DIFF
--- a/wiremock/templates/wiremockmocks.yaml
+++ b/wiremock/templates/wiremockmocks.yaml
@@ -3,34 +3,4 @@ kind: ConfigMap
 metadata:
   name: {{ template "hmcts.wiremock.releaseName" . }}-wm
 data:
-  liveness-mock.json: |
-    {
-      "request": {
-        "method": "GET",
-        "url": "/health/liveness"
-      },
-      "response": {
-        "status": 200
-      }
-    }
-  liveness-mock-2.json: |
-    {
-      "request": {
-        "method": "GET",
-        "url": "/health"
-      },
-      "response": {
-        "status": 200
-      }
-    }  
-  readiness-mock.json: |
-    {
-      "request": {
-        "method": "GET",
-        "url": "/health/readiness"
-      },
-      "response": {
-        "status": 200
-      }
-    }
-
+  {{- .Values.initialMappings | toYaml | nindent 2 }}

--- a/wiremock/values.yaml
+++ b/wiremock/values.yaml
@@ -100,3 +100,35 @@ autoscaling:
     enabled: true
     averageUtilization: 80
 useWorkloadIdentity: true
+
+initialMappings:
+  liveness-mock.json: |
+    {
+      "request": {
+        "method": "GET",
+        "url": "/health/liveness"
+      },
+      "response": {
+        "status": 200
+      }
+    }
+  liveness-mock-2.json: |
+    {
+      "request": {
+        "method": "GET",
+        "url": "/health"
+      },
+      "response": {
+        "status": 200
+      }
+    }
+  readiness-mock.json: |
+    {
+      "request": {
+        "method": "GET",
+        "url": "/health/readiness"
+      },
+      "response": {
+        "status": 200
+      }
+    }


### PR DESCRIPTION
### Jira link

See [HDPI-3496](https://tools.hmcts.net/jira/browse/HDPI-3496)

### Change description

Extract initial wiremock mappings to values file, so they can be overridden in other charts that use this one.

### Testing done

Rendered the template before and after the changes to compare the generated YAML. The only difference was the order of the items in the map.

Added this chart as a local dependency to pcs-api and rendered the full chart output before and after. As before, the only difference was the order of the items in the map.

Finally, confirmed that is is possible to override the default mappings using a values file in the depending service.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
